### PR TITLE
Add power-up guide with icons to main menu

### DIFF
--- a/src/game/game.js
+++ b/src/game/game.js
@@ -37,6 +37,51 @@ const POWER_UP_SEQUENCE = [
   POWER_UP_TYPES.GUN,
 ];
 
+const POWER_UP_DETAILS = [
+  {
+    type: POWER_UP_TYPES.HELMET,
+    name: '头盔',
+    description: '获得 10 秒护盾，免疫伤害。',
+    icon: '🪖',
+  },
+  {
+    type: POWER_UP_TYPES.TIMER,
+    name: '闹钟',
+    description: '冻结所有敌军 5 秒。',
+    icon: '⏱️',
+  },
+  {
+    type: POWER_UP_TYPES.SHOVEL,
+    name: '铲子',
+    description: '加固基地周围墙体 15 秒。',
+    icon: '⛏️',
+  },
+  {
+    type: POWER_UP_TYPES.STAR,
+    name: '星星',
+    description: '坦克升级 1 级（最多 3 级）。',
+    icon: '⭐',
+  },
+  {
+    type: POWER_UP_TYPES.GRENADE,
+    name: '手雷',
+    description: '立即摧毁场上全部敌军坦克。',
+    icon: '💣',
+  },
+  {
+    type: POWER_UP_TYPES.TANK,
+    name: '坦克',
+    description: '增加一条生命值。',
+    icon: '❤️',
+  },
+  {
+    type: POWER_UP_TYPES.GUN,
+    name: '加农炮',
+    description: '直接提升至满级火力。',
+    icon: '🔫',
+  },
+];
+
 const POWER_TILE_BRICK = [
   TILE_TYPES.BRICK,
   TILE_TYPES.BRICK,
@@ -163,10 +208,28 @@ export class Game {
   }
 
   updateMenu() {
+    const powerUpList = POWER_UP_DETAILS.map(
+      ({ icon, name, description, type }) => `
+        <div class="powerup-card" data-power-up="${type}">
+          <div class="powerup-icon" aria-hidden="true">${icon}</div>
+          <div class="powerup-info">
+            <div class="powerup-name">${name}</div>
+            <div class="powerup-desc">${description}</div>
+          </div>
+        </div>
+      `,
+    ).join('');
+
     this.overlay.innerHTML = `
       <div class="title">BATTLE CITY</div>
       <div class="menu-option" data-action="start">1 PLAYER</div>
       <div class="menu-option" data-action="toggle-audio">音效：${this.audio.enabled ? '开' : '关'}</div>
+      <div class="powerup-guide">
+        <div class="powerup-guide-title">掉落道具一览</div>
+        <div class="powerup-grid">
+          ${powerUpList}
+        </div>
+      </div>
     `;
     this.overlay.classList.add('active');
     this.overlay.onclick = (event) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -113,6 +113,7 @@ canvas {
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.2s ease;
+  overflow-y: auto;
 }
 
 .overlay.active {
@@ -138,6 +139,71 @@ canvas {
 .overlay .menu-option:hover,
 .overlay .menu-option.active {
   background: rgba(255, 179, 71, 0.2);
+}
+
+.overlay .powerup-guide,
+.overlay .powerup-guide * {
+  text-transform: none;
+}
+
+.overlay .powerup-guide {
+  width: 100%;
+  max-width: 360px;
+  background: rgba(0, 0, 0, 0.45);
+  border: 2px solid #2a2a2a;
+  border-radius: 10px;
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 14px;
+  line-height: 1.5;
+  text-align: left;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.overlay .powerup-guide-title {
+  font-size: 16px;
+  color: var(--accent);
+  letter-spacing: 0.5px;
+}
+
+.overlay .powerup-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.overlay .powerup-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+}
+
+.overlay .powerup-icon {
+  font-size: 28px;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.35));
+}
+
+.overlay .powerup-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.overlay .powerup-name {
+  font-size: 14px;
+  color: var(--text);
+}
+
+.overlay .powerup-desc {
+  font-size: 12px;
+  color: #cdd2d7;
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- add a curated list of all droppable power-ups to the main menu overlay
- pair each entry with an illustrative icon and localized description for clarity
- style the overlay to support the new guide while keeping the rest of the UI responsive

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d88fcb1d9483309a4b5f4e9d75db93