### PR TITLE
Add toggleable power-up guide and in-level icons

### DIFF
--- a/src/core/input.js
+++ b/src/core/input.js
@@ -7,6 +7,7 @@ const KEY_BINDINGS = {
   Enter: 'pause',
   KeyM: 'mute',
   KeyP: 'pause',
+  KeyH: 'help',
 };
 
 export class Input {

--- a/src/data/powerUps.js
+++ b/src/data/powerUps.js
@@ -1,0 +1,51 @@
+import { POWER_UP_TYPES } from '../core/config.js';
+
+export const POWER_UP_DETAILS = [
+  {
+    type: POWER_UP_TYPES.HELMET,
+    name: '头盔',
+    description: '获得 10 秒护盾，免疫伤害。',
+    icon: '🪖',
+  },
+  {
+    type: POWER_UP_TYPES.TIMER,
+    name: '闹钟',
+    description: '冻结所有敌军 5 秒。',
+    icon: '⏱️',
+  },
+  {
+    type: POWER_UP_TYPES.SHOVEL,
+    name: '铲子',
+    description: '加固基地周围墙体 15 秒。',
+    icon: '⛏️',
+  },
+  {
+    type: POWER_UP_TYPES.STAR,
+    name: '星星',
+    description: '坦克升级 1 级（最多 3 级）。',
+    icon: '⭐',
+  },
+  {
+    type: POWER_UP_TYPES.GRENADE,
+    name: '手雷',
+    description: '立即摧毁场上全部敌军坦克。',
+    icon: '💣',
+  },
+  {
+    type: POWER_UP_TYPES.TANK,
+    name: '坦克',
+    description: '增加一条生命值。',
+    icon: '❤️',
+  },
+  {
+    type: POWER_UP_TYPES.GUN,
+    name: '加农炮',
+    description: '直接提升至满级火力。',
+    icon: '🔫',
+  },
+];
+
+export const POWER_UP_ICON_MAP = POWER_UP_DETAILS.reduce((map, { type, icon }) => {
+  map[type] = icon;
+  return map;
+}, {});

--- a/src/entities/powerUp.js
+++ b/src/entities/powerUp.js
@@ -1,4 +1,5 @@
 import { TILE_SIZE, POWER_UP_TYPES } from '../core/config.js';
+import { POWER_UP_ICON_MAP } from '../data/powerUps.js';
 
 const COLORS = {
   [POWER_UP_TYPES.HELMET]: '#ffe066',
@@ -30,11 +31,23 @@ export class PowerUp {
 
   render(ctx) {
     if (!this.alive) return;
+    ctx.save();
     ctx.fillStyle = COLORS[this.type] || '#fff';
     ctx.fillRect(this.x, this.y, this.width, this.height);
-    ctx.fillStyle = '#222';
-    ctx.font = '12px monospace';
-    ctx.textBaseline = 'bottom';
-    ctx.fillText(this.type[0].toUpperCase(), this.x + 4, this.y + TILE_SIZE - 4);
+
+    const icon = POWER_UP_ICON_MAP[this.type];
+    if (icon) {
+      ctx.font = `${Math.floor(TILE_SIZE * 0.9)}px "Noto Color Emoji", "Segoe UI Emoji", system-ui`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(icon, this.x + this.width / 2, this.y + this.height / 2 + 1);
+    } else {
+      ctx.fillStyle = '#222';
+      ctx.font = '12px monospace';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(this.type[0].toUpperCase(), this.x + 4, this.y + TILE_SIZE - 4);
+    }
+    ctx.restore();
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -141,6 +141,13 @@ canvas {
   background: rgba(255, 179, 71, 0.2);
 }
 
+.overlay .menu-hint {
+  margin-top: 18px;
+  font-size: 12px;
+  color: #cdd2d7;
+  letter-spacing: 0.5px;
+}
+
 .overlay .powerup-guide,
 .overlay .powerup-guide * {
   text-transform: none;


### PR DESCRIPTION
## Summary
- render collectible power-ups with their emoji icons instead of placeholder letters
- move power-up metadata into a shared module and add an H key shortcut that toggles a guide overlay from the main menu
- show a main menu hint for the new shortcut while keeping the gameplay HUD clean

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d893ac417483308f9b928ee4eb58a0