### PR TITLE
Expose game instance for browser smoke tests

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,11 @@ const hud = {
 
 const game = new Game({ canvas, overlay, hud });
 
+// Expose the game instance for automated smoke tests and debugging.
+// This allows Playwright-based checks to trigger gameplay actions
+// (e.g. spawning power-ups) without relying on manual input.
+window.__tankBattleGame = game;
+
 game.init().then(() => {
   game.start();
 });


### PR DESCRIPTION
## Summary
- expose the instantiated Game object on the global window so external tools can drive gameplay for smoke checks

## Testing
- manual Playwright script to start a stage and spawn a power-up (see attached evidence)


------
https://chatgpt.com/codex/tasks/task_e_68d89fe228a883309fd996d1a0f7de6f