### PR TITLE
Refresh visuals with SVG sprites

### DIFF
--- a/src/assets/svg/effects/bullet.svg
+++ b/src/assets/svg/effects/bullet.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <linearGradient id="bulletGlow" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#fff7d6" />
+      <stop offset="0.5" stop-color="#ffcf58" />
+      <stop offset="1" stop-color="#ff8f1f" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="1" width="4" height="14" rx="2" fill="url(#bulletGlow)" />
+  <rect x="6.5" y="1.5" width="3" height="4" rx="1.4" fill="#ffffff" opacity="0.8" />
+</svg>

--- a/src/assets/svg/effects/shield.svg
+++ b/src/assets/svg/effects/shield.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <radialGradient id="shieldGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.9" />
+      <stop offset="0.5" stop-color="#8ff7ff" stop-opacity="0.6" />
+      <stop offset="1" stop-color="#24d1ff" stop-opacity="0.2" />
+    </radialGradient>
+  </defs>
+  <circle cx="16" cy="16" r="13" fill="url(#shieldGlow)" />
+  <circle cx="16" cy="16" r="12" fill="none" stroke="#e7feff" stroke-width="2" opacity="0.8" />
+</svg>

--- a/src/assets/svg/powerups/grenade.svg
+++ b/src/assets/svg/powerups/grenade.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="grenadeBody" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#ff9f9f" />
+      <stop offset="1" stop-color="#ff4b4b" />
+    </linearGradient>
+  </defs>
+  <circle cx="16" cy="18" r="9" fill="url(#grenadeBody)" />
+  <rect x="13" y="6" width="6" height="5" rx="2" fill="#b73232" />
+  <path d="M12 6c0-1.6 1.4-3 3-3h2c1.6 0 3 1.4 3 3" fill="none" stroke="#ffd0d0" stroke-width="2" />
+  <rect x="11" y="16" width="10" height="5" rx="2" fill="#ffdbdb" opacity="0.6" />
+</svg>

--- a/src/assets/svg/powerups/gun.svg
+++ b/src/assets/svg/powerups/gun.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="gunBarrel" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#ffd87c" />
+      <stop offset="1" stop-color="#ff9800" />
+    </linearGradient>
+  </defs>
+  <rect x="10" y="8" width="12" height="16" rx="3" fill="#444" />
+  <rect x="12" y="10" width="8" height="12" rx="2" fill="#222" />
+  <rect x="14" y="4" width="4" height="12" rx="1.5" fill="url(#gunBarrel)" />
+  <rect x="9" y="18" width="14" height="4" rx="2" fill="#ffb347" />
+</svg>

--- a/src/assets/svg/powerups/helmet.svg
+++ b/src/assets/svg/powerups/helmet.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="helmetBody" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#ffe577" />
+      <stop offset="1" stop-color="#f5a623" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="10" width="20" height="12" rx="6" fill="url(#helmetBody)" />
+  <rect x="8" y="12" width="16" height="8" rx="4" fill="#fff3c0" opacity="0.8" />
+  <rect x="12" y="8" width="8" height="4" rx="2" fill="#fbe9a0" />
+  <rect x="10" y="18" width="12" height="4" rx="2" fill="#d9861e" />
+</svg>

--- a/src/assets/svg/powerups/shovel.svg
+++ b/src/assets/svg/powerups/shovel.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="14.5" y="4" width="3" height="14" rx="1.5" fill="#c8a16a" />
+  <path d="M13 4h6l-1.2 4h-3.6z" fill="#f1d4a7" />
+  <path d="M11 18c0-3 5-8 5-8s5 5 5 8-2.2 7-5 7-5-4-5-7z" fill="#8b5a2b" />
+  <path d="M16 24c1.6 0 3-1.8 3-3.5S16 14 16 14s-3 4.5-3 6.5 1.4 3.5 3 3.5z" fill="#c59455" />
+</svg>

--- a/src/assets/svg/powerups/star.svg
+++ b/src/assets/svg/powerups/star.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <radialGradient id="starGlow" cx="0.5" cy="0.5" r="0.6">
+      <stop offset="0" stop-color="#fff9d5" />
+      <stop offset="1" stop-color="#ffcb2f" />
+    </radialGradient>
+  </defs>
+  <circle cx="16" cy="16" r="12" fill="rgba(255, 220, 90, 0.28)" />
+  <path d="M16 6l3 7h7l-5.5 4.2L22 26l-6-3.8L10 26l1.5-8.8L6 13h7z" fill="url(#starGlow)" stroke="#ffd45c" stroke-width="1" />
+</svg>

--- a/src/assets/svg/powerups/tank.svg
+++ b/src/assets/svg/powerups/tank.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="6" y="10" width="20" height="12" rx="6" fill="#6bd36b" />
+  <rect x="8" y="12" width="16" height="8" rx="4" fill="#d1ffd1" opacity="0.8" />
+  <rect x="14.5" y="6" width="3" height="6" rx="1.4" fill="#8afc8a" />
+  <path d="M10 18h12" stroke="#2f7f2f" stroke-width="2.5" stroke-linecap="round" />
+  <path d="M12 20h8" stroke="#2f7f2f" stroke-width="2.5" stroke-linecap="round" />
+</svg>

--- a/src/assets/svg/powerups/timer.svg
+++ b/src/assets/svg/powerups/timer.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="timerBody" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#8fe4ff" />
+      <stop offset="1" stop-color="#3390ff" />
+    </linearGradient>
+  </defs>
+  <circle cx="16" cy="18" r="10" fill="url(#timerBody)" />
+  <circle cx="16" cy="18" r="7" fill="#f0fbff" />
+  <rect x="13" y="6" width="6" height="4" rx="2" fill="#2d78ff" />
+  <path d="M16 11v6l4 2" fill="none" stroke="#2d78ff" stroke-width="2" stroke-linecap="round" />
+</svg>

--- a/src/assets/svg/tanks/enemy-armor.svg
+++ b/src/assets/svg/tanks/enemy-armor.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="3" fill="#5b7fa3" />
+  <rect x="2.5" y="2.5" width="11" height="11" rx="2.5" fill="#0f1a25" />
+  <rect x="6.5" y="1" width="3" height="6" rx="1.2" fill="#9fc2e8" />
+  <rect x="3.2" y="6.5" width="9.6" height="6" rx="1" fill="#89a9c9" opacity="0.95" />
+  <circle cx="8" cy="9.5" r="2.4" fill="#050d16" />
+  <circle cx="8" cy="9.5" r="1.1" fill="#c7d9ef" />
+</svg>

--- a/src/assets/svg/tanks/enemy-basic.svg
+++ b/src/assets/svg/tanks/enemy-basic.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="3" fill="#ff6b3a" />
+  <rect x="2.5" y="2.5" width="11" height="11" rx="2.5" fill="#1f0f08" />
+  <rect x="6.5" y="1" width="3" height="6" rx="1.2" fill="#ffb08a" />
+  <rect x="3.3" y="6.5" width="9.4" height="6" rx="1" fill="#ff8a55" opacity="0.85" />
+  <circle cx="8" cy="9.5" r="2.4" fill="#130804" />
+  <circle cx="8" cy="9.5" r="1.1" fill="#ffcfb3" />
+</svg>

--- a/src/assets/svg/tanks/enemy-fast.svg
+++ b/src/assets/svg/tanks/enemy-fast.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="3" fill="#f7f7f7" />
+  <rect x="2.5" y="2.5" width="11" height="11" rx="2.5" fill="#1a1a1a" />
+  <rect x="6.5" y="1" width="3" height="6" rx="1.2" fill="#ffffff" />
+  <rect x="3.5" y="6.5" width="9" height="6" rx="1" fill="#d5d5d5" opacity="0.9" />
+  <circle cx="8" cy="9.5" r="2.3" fill="#0d0d0d" />
+  <circle cx="8" cy="9.5" r="1.1" fill="#f7f7f7" />
+</svg>

--- a/src/assets/svg/tanks/enemy-power.svg
+++ b/src/assets/svg/tanks/enemy-power.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="3" fill="#ffce42" />
+  <rect x="2.5" y="2.5" width="11" height="11" rx="2.5" fill="#261a04" />
+  <rect x="6.5" y="1" width="3" height="6" rx="1.2" fill="#ffe28a" />
+  <rect x="3.2" y="6.5" width="9.6" height="6" rx="1" fill="#ffdc6c" opacity="0.9" />
+  <circle cx="8" cy="9.5" r="2.4" fill="#120a02" />
+  <circle cx="8" cy="9.5" r="1.1" fill="#ffd54f" />
+</svg>

--- a/src/assets/svg/tanks/player.svg
+++ b/src/assets/svg/tanks/player.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="3" fill="#f6c945" />
+  <rect x="2.5" y="2.5" width="11" height="11" rx="2.5" fill="#3c2e12" />
+  <rect x="6.5" y="1" width="3" height="6" rx="1.2" fill="#ffe899" />
+  <rect x="3.5" y="6.5" width="9" height="6" rx="1" fill="#f2b705" opacity="0.9" />
+  <circle cx="8" cy="9.5" r="2.5" fill="#1b1405" />
+  <circle cx="8" cy="9.5" r="1.3" fill="#f6c945" />
+</svg>

--- a/src/assets/svg/tiles/base.svg
+++ b/src/assets/svg/tiles/base.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="2" fill="#5e4021" />
+  <rect x="1.5" y="1.5" width="13" height="13" rx="1.5" fill="#8b5e2e" />
+  <path d="M3 12h10v2H3z" fill="#3b2916" opacity="0.8" />
+  <path d="M5 4h6v6H5z" fill="#d7a34b" />
+  <path d="M5 4l3-2 3 2H5z" fill="#f0c674" />
+</svg>

--- a/src/assets/svg/tiles/brick.svg
+++ b/src/assets/svg/tiles/brick.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <linearGradient id="brickShadow" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#f0773d" />
+      <stop offset="1" stop-color="#a53e1f" />
+    </linearGradient>
+  </defs>
+  <rect width="16" height="16" fill="url(#brickShadow)" rx="1" />
+  <g fill="#742413" opacity="0.55">
+    <rect x="0" y="5" width="16" height="1" />
+    <rect x="0" y="11" width="16" height="1" />
+    <rect x="0" y="2" width="16" height="1" />
+  </g>
+  <g fill="#e99b79" opacity="0.55">
+    <rect x="1" y="1" width="3.5" height="1" rx="0.5" />
+    <rect x="6" y="1" width="4" height="1" rx="0.5" />
+    <rect x="11.5" y="1" width="3" height="1" rx="0.5" />
+    <rect x="2" y="7" width="4" height="1" rx="0.5" />
+    <rect x="9.5" y="7" width="4" height="1" rx="0.5" />
+    <rect x="1" y="13" width="3.5" height="1" rx="0.5" />
+    <rect x="6" y="13" width="4" height="1" rx="0.5" />
+  </g>
+</svg>

--- a/src/assets/svg/tiles/eagle.svg
+++ b/src/assets/svg/tiles/eagle.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="2" fill="#1f1b2e" />
+  <path d="M8 2l2 3h3l-2 3 2 3H9l-1 3-1-3H5l2-3-2-3h3z" fill="#f5e6a2" />
+  <path d="M8 4l1 1.6h1.6L9 7l1.6 1.4H9L8 10 7 8.4H5.4L7 7 5.4 5.6H7z" fill="#fffbdb" />
+</svg>

--- a/src/assets/svg/tiles/grass.svg
+++ b/src/assets/svg/tiles/grass.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="2" fill="#2f7a3d" />
+  <g fill="#48c774">
+    <path d="M1 15c2-4 4-4 6 0H1z" />
+    <path d="M6 15c1.5-5 3-5 4.5 0H6z" />
+    <path d="M10 15c1.8-4.5 3.6-4.5 5.4 0H10z" />
+  </g>
+  <g fill="#a9f0c3" opacity="0.7">
+    <circle cx="4" cy="5" r="1.1" />
+    <circle cx="8" cy="3.5" r="1" />
+    <circle cx="12" cy="6" r="1.2" />
+  </g>
+</svg>

--- a/src/assets/svg/tiles/ice.svg
+++ b/src/assets/svg/tiles/ice.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <linearGradient id="iceGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#e9f6ff" />
+      <stop offset="1" stop-color="#90c6ff" />
+    </linearGradient>
+  </defs>
+  <rect width="16" height="16" rx="2" fill="url(#iceGradient)" />
+  <g fill="#fff" opacity="0.7">
+    <path d="M2 8l3-6 3 6-3 6-3-6z" />
+    <path d="M8 2l2.2 4.4L14 8l-3.8 1.6L8 14l-2.2-4.4L2 8l3.8-1.6L8 2z" opacity="0.5" />
+  </g>
+</svg>

--- a/src/assets/svg/tiles/steel.svg
+++ b/src/assets/svg/tiles/steel.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <linearGradient id="steelBase" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f5f7fa" />
+      <stop offset="0.5" stop-color="#9da7b8" />
+      <stop offset="1" stop-color="#5b6578" />
+    </linearGradient>
+  </defs>
+  <rect width="16" height="16" rx="2" fill="url(#steelBase)" />
+  <rect x="1" y="1" width="14" height="14" rx="1.5" fill="#141921" opacity="0.6" />
+  <g fill="#d7dee8" opacity="0.65">
+    <rect x="1.5" y="1.5" width="13" height="2" rx="1" />
+    <rect x="1.5" y="12.5" width="13" height="2" rx="1" />
+    <rect x="1.5" y="4.8" width="13" height="2" rx="1" />
+    <rect x="1.5" y="9.2" width="13" height="2" rx="1" />
+  </g>
+</svg>

--- a/src/assets/svg/tiles/water.svg
+++ b/src/assets/svg/tiles/water.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <linearGradient id="waterGradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#4fc0ff" />
+      <stop offset="1" stop-color="#166bff" />
+    </linearGradient>
+  </defs>
+  <rect width="16" height="16" rx="2" fill="url(#waterGradient)" />
+  <g fill="none" stroke="#e8f7ff" stroke-width="1.2" opacity="0.75" stroke-linecap="round">
+    <path d="M2 6c1.2-1.2 2.4-1.2 3.6 0s2.4 1.2 3.6 0 2.4-1.2 3.6 0 2.4 1.2 3.6 0" />
+    <path d="M1 10c1.2 1.4 2.4 1.4 3.6 0s2.4-1.4 3.6 0 2.4 1.4 3.6 0 2.4-1.4 3.6 0" />
+  </g>
+</svg>

--- a/src/core/assets.js
+++ b/src/core/assets.js
@@ -1,0 +1,93 @@
+const resolvePath = (relativePath) => new URL(`../${relativePath}`, import.meta.url).href;
+
+const DEFAULT_MANIFEST = {
+  tiles: {
+    brick: resolvePath('assets/svg/tiles/brick.svg'),
+    steel: resolvePath('assets/svg/tiles/steel.svg'),
+    water: resolvePath('assets/svg/tiles/water.svg'),
+    grass: resolvePath('assets/svg/tiles/grass.svg'),
+    ice: resolvePath('assets/svg/tiles/ice.svg'),
+    base: resolvePath('assets/svg/tiles/base.svg'),
+    eagle: resolvePath('assets/svg/tiles/eagle.svg'),
+  },
+  tanks: {
+    player: resolvePath('assets/svg/tanks/player.svg'),
+    enemies: {
+      basic: resolvePath('assets/svg/tanks/enemy-basic.svg'),
+      fast: resolvePath('assets/svg/tanks/enemy-fast.svg'),
+      power: resolvePath('assets/svg/tanks/enemy-power.svg'),
+      armor: resolvePath('assets/svg/tanks/enemy-armor.svg'),
+    },
+  },
+  effects: {
+    bullet: resolvePath('assets/svg/effects/bullet.svg'),
+    shield: resolvePath('assets/svg/effects/shield.svg'),
+  },
+  powerUps: {
+    helmet: resolvePath('assets/svg/powerups/helmet.svg'),
+    timer: resolvePath('assets/svg/powerups/timer.svg'),
+    shovel: resolvePath('assets/svg/powerups/shovel.svg'),
+    star: resolvePath('assets/svg/powerups/star.svg'),
+    grenade: resolvePath('assets/svg/powerups/grenade.svg'),
+    tank: resolvePath('assets/svg/powerups/tank.svg'),
+    gun: resolvePath('assets/svg/powerups/gun.svg'),
+  },
+};
+
+export async function loadSvgSprites(manifest = DEFAULT_MANIFEST) {
+  return await traverseManifest(manifest);
+}
+
+export { DEFAULT_MANIFEST as ASSET_MANIFEST };
+
+async function traverseManifest(node) {
+  if (typeof node === 'string') {
+    const src = node;
+    const image = await loadSvg(src);
+    return { image, src };
+  }
+
+  if (Array.isArray(node)) {
+    return Promise.all(node.map((value) => traverseManifest(value)));
+  }
+
+  const entries = await Promise.all(
+    Object.entries(node).map(async ([key, value]) => {
+      const resolved = await traverseManifest(value);
+      return [key, resolved];
+    })
+  );
+  return Object.fromEntries(entries);
+}
+
+async function loadSvg(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`无法加载资源 ${url}: ${response.status}`);
+  }
+  const blob = await response.blob();
+  if ('createImageBitmap' in window) {
+    try {
+      return await createImageBitmap(blob);
+    } catch (error) {
+      console.warn(`createImageBitmap 解析 ${url} 失败，改用 <img> 回退。`, error);
+    }
+  }
+  return await blobToImage(blob);
+}
+
+function blobToImage(blob) {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const image = new Image();
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(image);
+    };
+    image.onerror = (error) => {
+      URL.revokeObjectURL(url);
+      reject(error);
+    };
+    image.src = url;
+  });
+}

--- a/src/core/input.js
+++ b/src/core/input.js
@@ -7,6 +7,7 @@ const KEY_BINDINGS = {
   Enter: 'pause',
   KeyM: 'mute',
   KeyP: 'pause',
+  KeyH: 'help',
 };
 
 export class Input {

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -1,25 +1,34 @@
-import { TILE_SIZE, TILE_TYPES, FIELD_SIZE } from './config.js';
+import { TILE_SIZE, TILE_TYPES, FIELD_SIZE, DIRECTION, ENEMY_TYPES } from './config.js';
 
 const COLORS = {
   background: '#000',
-  brick: '#b5522b',
-  steel: '#b5b5b5',
-  water: '#2244ff',
-  grass: '#3aa35c',
-  ice: '#a8d0f0',
-  base: '#d1a368',
-  eagle: '#f4f0c0',
-  player: '#f0e47a',
-  enemyBasic: '#d96230',
-  enemyFast: '#f4f4f4',
-  enemyPower: '#f7c948',
-  enemyArmor: '#9ab0c2',
-  bullet: '#f7f7f7',
-  shield: '#ffef67',
+  fallback: {
+    brick: '#b5522b',
+    steel: '#b5b5b5',
+    water: '#2244ff',
+    grass: '#3aa35c',
+    ice: '#a8d0f0',
+    base: '#d1a368',
+    eagle: '#f4f0c0',
+    player: '#f0e47a',
+    enemyBasic: '#d96230',
+    enemyFast: '#f4f4f4',
+    enemyPower: '#f7c948',
+    enemyArmor: '#9ab0c2',
+    bullet: '#f7f7f7',
+    shield: '#ffef67',
+  },
+};
+
+const DIRECTION_ANGLE = {
+  [DIRECTION.UP]: 0,
+  [DIRECTION.RIGHT]: Math.PI / 2,
+  [DIRECTION.DOWN]: Math.PI,
+  [DIRECTION.LEFT]: -Math.PI / 2,
 };
 
 export class Renderer {
-  constructor(canvas) {
+  constructor(canvas, assets = null) {
     this.canvas = canvas;
     this.ctx = canvas.getContext('2d');
     this.scratch = document.createElement('canvas');
@@ -27,10 +36,14 @@ export class Renderer {
     this.scratch.height = FIELD_SIZE;
     this.sctx = this.scratch.getContext('2d');
     this.grassTiles = [];
+    this.setAssets(assets);
+    this.ctx.imageSmoothingEnabled = false;
+    this.sctx.imageSmoothingEnabled = false;
   }
 
   drawLevel(level) {
     const ctx = this.sctx;
+    ctx.clearRect(0, 0, FIELD_SIZE, FIELD_SIZE);
     ctx.fillStyle = COLORS.background;
     ctx.fillRect(0, 0, FIELD_SIZE, FIELD_SIZE);
     this.grassTiles = [];
@@ -42,47 +55,81 @@ export class Renderer {
           this.grassTiles.push({ x, y });
           continue;
         }
-        ctx.fillStyle = tileColor(tile);
-        ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
-        if (tile === TILE_TYPES.WATER) {
-          ctx.strokeStyle = '#3366ff';
-          ctx.lineWidth = 1;
-          ctx.strokeRect(x * TILE_SIZE + 3, y * TILE_SIZE + 3, TILE_SIZE - 6, TILE_SIZE - 6);
-        }
-        if (tile === TILE_TYPES.STEEL) {
-          ctx.strokeStyle = '#ffffff44';
-          ctx.lineWidth = 1;
-          ctx.strokeRect(x * TILE_SIZE + 1, y * TILE_SIZE + 1, TILE_SIZE - 2, TILE_SIZE - 2);
+        const sprite = this.getTileSprite(tile);
+        if (sprite) {
+          ctx.drawImage(sprite, x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+        } else {
+          ctx.fillStyle = tileColor(tile);
+          ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
         }
       }
     }
   }
 
   drawTank(ctx, tank) {
-    ctx.save();
-    ctx.translate(tank.x, tank.y);
-    ctx.fillStyle = tank.isPlayer
-      ? COLORS.player
-      : {
-          basic: COLORS.enemyBasic,
-          fast: COLORS.enemyFast,
-          power: COLORS.enemyPower,
-          armor: COLORS.enemyArmor,
-        }[tank.type || 'basic'];
-    ctx.fillRect(0, 0, tank.width, tank.height);
-    ctx.fillStyle = '#333';
-    ctx.fillRect(3, 3, tank.width - 6, tank.height - 6);
-    ctx.restore();
+    const sprite = this.getTankSprite(tank);
+    if (sprite) {
+      const centerX = tank.x + tank.width / 2;
+      const centerY = tank.y + tank.height / 2;
+      ctx.save();
+      ctx.translate(centerX, centerY);
+      const angle = DIRECTION_ANGLE[tank.direction] ?? 0;
+      ctx.rotate(angle);
+      ctx.drawImage(sprite, -tank.width / 2, -tank.height / 2, tank.width, tank.height);
+      ctx.restore();
+    } else {
+      ctx.save();
+      ctx.translate(tank.x, tank.y);
+      ctx.fillStyle = tank.isPlayer
+        ? COLORS.fallback.player
+        : {
+            [ENEMY_TYPES.BASIC]: COLORS.fallback.enemyBasic,
+            [ENEMY_TYPES.FAST]: COLORS.fallback.enemyFast,
+            [ENEMY_TYPES.POWER]: COLORS.fallback.enemyPower,
+            [ENEMY_TYPES.ARMOR]: COLORS.fallback.enemyArmor,
+          }[tank.type || ENEMY_TYPES.BASIC];
+      ctx.fillRect(0, 0, tank.width, tank.height);
+      ctx.fillStyle = '#333';
+      ctx.fillRect(3, 3, tank.width - 6, tank.height - 6);
+      ctx.restore();
+    }
     if (tank.invincibleTimer > 0) {
-      ctx.strokeStyle = COLORS.shield;
-      ctx.lineWidth = 2;
-      ctx.strokeRect(tank.x + 2, tank.y + 2, tank.width - 4, tank.height - 4);
+      const shield = this.effectSprites?.shield;
+      if (shield) {
+        const alpha = 0.6 + 0.3 * Math.sin(Date.now() / 120);
+        ctx.save();
+        ctx.globalAlpha = Math.max(0.4, alpha);
+        ctx.drawImage(
+          shield,
+          tank.x + tank.width / 2 - TILE_SIZE,
+          tank.y + tank.height / 2 - TILE_SIZE,
+          TILE_SIZE * 2,
+          TILE_SIZE * 2
+        );
+        ctx.restore();
+      } else {
+        ctx.strokeStyle = COLORS.fallback.shield;
+        ctx.lineWidth = 2;
+        ctx.strokeRect(tank.x + 2, tank.y + 2, tank.width - 4, tank.height - 4);
+      }
     }
   }
 
   drawBullet(ctx, bullet) {
-    ctx.fillStyle = COLORS.bullet;
-    ctx.fillRect(bullet.x, bullet.y, bullet.width, bullet.height);
+    const sprite = this.effectSprites?.bullet;
+    if (sprite) {
+      const centerX = bullet.x + bullet.width / 2;
+      const centerY = bullet.y + bullet.height / 2;
+      ctx.save();
+      ctx.translate(centerX, centerY);
+      const angle = DIRECTION_ANGLE[bullet.direction] ?? 0;
+      ctx.rotate(angle);
+      ctx.drawImage(sprite, -bullet.width / 2, -bullet.height / 2, bullet.width, bullet.height);
+      ctx.restore();
+    } else {
+      ctx.fillStyle = COLORS.fallback.bullet;
+      ctx.fillRect(bullet.x, bullet.y, bullet.width, bullet.height);
+    }
   }
 
   composite(level, drawables = []) {
@@ -99,34 +146,79 @@ export class Renderer {
   drawGrassOverlay(ctx) {
     if (!this.grassTiles.length) return;
     ctx.save();
-    ctx.fillStyle = COLORS.grass;
-    ctx.globalAlpha = 0.85;
+    const sprite = this.tileSprites?.[TILE_TYPES.GRASS];
+    ctx.globalAlpha = 0.9;
     for (const tile of this.grassTiles) {
-      ctx.fillRect(tile.x * TILE_SIZE, tile.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
-      ctx.strokeStyle = '#2a803f';
-      ctx.lineWidth = 1;
-      ctx.strokeRect(tile.x * TILE_SIZE + 2, tile.y * TILE_SIZE + 2, TILE_SIZE - 4, TILE_SIZE - 4);
+      if (sprite) {
+        ctx.drawImage(sprite, tile.x * TILE_SIZE, tile.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+      } else {
+        ctx.fillStyle = COLORS.fallback.grass;
+        ctx.fillRect(tile.x * TILE_SIZE, tile.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+      }
     }
     ctx.restore();
+  }
+
+  setAssets(assets) {
+    this.assets = assets;
+    this.tileSprites = assets
+      ? {
+          [TILE_TYPES.BRICK]: assets.tiles?.brick?.image,
+          [TILE_TYPES.STEEL]: assets.tiles?.steel?.image,
+          [TILE_TYPES.WATER]: assets.tiles?.water?.image,
+          [TILE_TYPES.GRASS]: assets.tiles?.grass?.image,
+          [TILE_TYPES.ICE]: assets.tiles?.ice?.image,
+          [TILE_TYPES.BASE]: assets.tiles?.base?.image,
+          [TILE_TYPES.EAGLE]: assets.tiles?.eagle?.image,
+        }
+      : {};
+    this.tankSprites = assets
+      ? {
+          player: assets.tanks?.player?.image,
+          enemies: {
+            [ENEMY_TYPES.BASIC]: assets.tanks?.enemies?.basic?.image,
+            [ENEMY_TYPES.FAST]: assets.tanks?.enemies?.fast?.image,
+            [ENEMY_TYPES.POWER]: assets.tanks?.enemies?.power?.image,
+            [ENEMY_TYPES.ARMOR]: assets.tanks?.enemies?.armor?.image,
+          },
+        }
+      : null;
+    this.effectSprites = assets
+      ? {
+          bullet: assets.effects?.bullet?.image,
+          shield: assets.effects?.shield?.image,
+        }
+      : null;
+  }
+
+  getTileSprite(tile) {
+    return this.tileSprites?.[tile] ?? null;
+  }
+
+  getTankSprite(tank) {
+    if (tank.isPlayer) {
+      return this.tankSprites?.player ?? null;
+    }
+    return this.tankSprites?.enemies?.[tank.type || ENEMY_TYPES.BASIC] ?? null;
   }
 }
 
 function tileColor(tile) {
   switch (tile) {
     case TILE_TYPES.BRICK:
-      return COLORS.brick;
+      return COLORS.fallback.brick;
     case TILE_TYPES.STEEL:
-      return COLORS.steel;
+      return COLORS.fallback.steel;
     case TILE_TYPES.WATER:
-      return COLORS.water;
+      return COLORS.fallback.water;
     case TILE_TYPES.GRASS:
-      return COLORS.grass;
+      return COLORS.fallback.grass;
     case TILE_TYPES.ICE:
-      return COLORS.ice;
+      return COLORS.fallback.ice;
     case TILE_TYPES.BASE:
-      return COLORS.base;
+      return COLORS.fallback.base;
     case TILE_TYPES.EAGLE:
-      return COLORS.eagle;
+      return COLORS.fallback.eagle;
     default:
       return COLORS.background;
   }

--- a/src/entities/powerUp.js
+++ b/src/entities/powerUp.js
@@ -28,13 +28,26 @@ export class PowerUp {
     }
   }
 
-  render(ctx) {
+  render(ctx, assets) {
     if (!this.alive) return;
-    ctx.fillStyle = COLORS[this.type] || '#fff';
-    ctx.fillRect(this.x, this.y, this.width, this.height);
-    ctx.fillStyle = '#222';
-    ctx.font = '12px monospace';
-    ctx.textBaseline = 'bottom';
-    ctx.fillText(this.type[0].toUpperCase(), this.x + 4, this.y + TILE_SIZE - 4);
+    const flicker = this.timer < 3 && Math.floor(this.timer * 8) % 2 === 0;
+    if (flicker) {
+      return;
+    }
+    const sprite = assets?.powerUps?.[this.type]?.image;
+    if (sprite) {
+      ctx.save();
+      ctx.shadowColor = 'rgba(0, 0, 0, 0.4)';
+      ctx.shadowBlur = 6;
+      ctx.drawImage(sprite, this.x, this.y, this.width, this.height);
+      ctx.restore();
+    } else {
+      ctx.fillStyle = COLORS[this.type] || '#fff';
+      ctx.fillRect(this.x, this.y, this.width, this.height);
+      ctx.fillStyle = '#222';
+      ctx.font = '12px monospace';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(this.type[0].toUpperCase(), this.x + 4, this.y + TILE_SIZE - 4);
+    }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { Game } from './game/game.js';
+import { loadSvgSprites } from './core/assets.js';
 
 const canvas = document.getElementById('game-canvas');
 const overlay = document.getElementById('ui-overlay');
@@ -10,6 +11,25 @@ const hud = {
 
 const game = new Game({ canvas, overlay, hud });
 
-game.init().then(() => {
+async function bootstrap() {
+  overlay.classList.add('active');
+  overlay.innerHTML = '<div class="title">资源加载中...</div>';
+  try {
+    const assets = await loadSvgSprites();
+    game.setAssets(assets);
+  } catch (error) {
+    console.error('加载 SVG 资源失败', error);
+    overlay.innerHTML = '<div class="title">资源加载失败</div><div>请刷新页面重试</div>';
+    return;
+  }
+
+  try {
+    await game.init();
+  } catch (error) {
+    console.warn('游戏初始化失败，继续以静音模式运行。', error);
+    game.audio?.setEnabled(false);
+  }
   game.start();
-});
+}
+
+bootstrap();

--- a/src/styles.css
+++ b/src/styles.css
@@ -131,6 +131,59 @@ canvas {
   background: rgba(255, 179, 71, 0.2);
 }
 
+.overlay .menu-hint {
+  font-size: 12px;
+  color: #bbbbbb;
+  text-transform: none;
+}
+
+.overlay .help-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+  max-width: 360px;
+  text-align: left;
+  pointer-events: auto;
+  text-transform: none;
+}
+
+.overlay .help-item {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 16px;
+  background: rgba(12, 12, 12, 0.65);
+  border: 1px solid rgba(255, 179, 71, 0.25);
+  border-radius: 12px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.35);
+}
+
+.overlay .help-item-icon {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.35));
+}
+
+.overlay .help-item-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.overlay .help-item-title {
+  font-size: 16px;
+  color: var(--accent);
+}
+
+.overlay .help-item-description {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text);
+}
+
 .controls {
   display: flex;
   justify-content: space-around;


### PR DESCRIPTION
## Summary
- add an SVG asset manifest/loader and draw tiles, tanks, bullets, shields, and grass from sprite textures
- replace the power-up rendering and menu help overlay with shared SVG icons and refreshed layout
- preload art before booting the game and fall back to muted mode if audio init fails

## Testing
- Manual: Loaded the game locally, opened the help overlay, and captured the updated UI

------
https://chatgpt.com/codex/tasks/task_e_68d8ddcd59dc833092690d5a92971500