### PR TITLE
Fix player firing cooldown and spawn position

### DIFF
--- a/src/entities/tank.js
+++ b/src/entities/tank.js
@@ -1,4 +1,4 @@
-import { TILE_SIZE, DIRECTION, ENEMY_TYPES } from '../core/config.js';
+import { TILE_SIZE, DIRECTION, ENEMY_TYPES, FIELD_SIZE } from '../core/config.js';
 import { clamp, coordToTile, isInsideField, randomChoice } from '../core/utils.js';
 
 export class Tank {
@@ -128,7 +128,14 @@ function rectOverlap(x1, y1, w1, h1, x2, y2, w2, h2) {
 }
 
 export class PlayerTank extends Tank {
-  constructor({ x, y }) {
+  static getDefaultSpawnPosition() {
+    return {
+      x: FIELD_SIZE / 2 - TILE_SIZE,
+      y: FIELD_SIZE - TILE_SIZE * 3,
+    };
+  }
+
+  constructor({ x, y } = PlayerTank.getDefaultSpawnPosition()) {
     super({ x, y, speed: 60, direction: DIRECTION.UP, isPlayer: true });
     this.level = 0;
     this.lives = 3;
@@ -186,17 +193,21 @@ export class PlayerTank extends Tank {
 
   fire(createBullet) {
     this.maxBullets = this.level >= 2 ? 2 : 1;
-    this.cooldown = this.level >= 3 ? 0.15 : 0.2;
+    const bulletsBefore = this.bullets.size;
     super.fire(createBullet);
+    if (this.bullets.size > bulletsBefore) {
+      this.cooldown = this.level >= 3 ? 0.15 : 0.2;
+    }
   }
 
   upgrade() {
     this.level = Math.min(3, this.level + 1);
   }
 
-  reset(position) {
-    this.x = position.x;
-    this.y = position.y;
+  reset(position = PlayerTank.getDefaultSpawnPosition()) {
+    const spawn = position ?? PlayerTank.getDefaultSpawnPosition();
+    this.x = spawn.x;
+    this.y = spawn.y;
     this.direction = DIRECTION.UP;
     this.cooldown = 0;
     this.alive = true;

--- a/src/game/game.js
+++ b/src/game/game.js
@@ -388,7 +388,7 @@ export class Game {
     this.stageScore = 0;
     this.lastCompletedStage = -1;
     this.hud.stage.textContent = formatStage(this.levelIndex + 1);
-    this.player = new PlayerTank({ x: FIELD_SIZE / 2 - TILE_SIZE, y: FIELD_SIZE - TILE_SIZE * 2 });
+    this.player = new PlayerTank(PlayerTank.getDefaultSpawnPosition());
     this.player.lives = PLAYER_BASE_LIVES;
     this.hud.score.textContent = formatScore(this.score);
     this.baseDestroyed = false;
@@ -420,7 +420,7 @@ export class Game {
     };
     this.stageIntroTimer = 2.5;
     this.hud.stage.textContent = formatStage(this.levelIndex + 1);
-    this.player.reset({ x: FIELD_SIZE / 2 - TILE_SIZE, y: FIELD_SIZE - TILE_SIZE * 2 });
+    this.player.reset(PlayerTank.getDefaultSpawnPosition());
     setTimeout(() => this.audio.playTheme('battle', { loop: true }), 2000);
   }
 
@@ -584,7 +584,7 @@ export class Game {
   handlePlayerDeath() {
     if (this.player.lives > 0) {
       this.player.lives -= 1;
-      this.player.reset({ x: FIELD_SIZE / 2 - TILE_SIZE, y: FIELD_SIZE - TILE_SIZE * 2 });
+      this.player.reset(PlayerTank.getDefaultSpawnPosition());
     } else {
       this.handleGameOver();
     }


### PR DESCRIPTION
## Summary
- adjust the player tank firing logic to apply cooldowns only after a shot is created
- centralize the player spawn position and shift it outside of the base walls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8f9de3c40833091613109bee9ad6e